### PR TITLE
feat: Support SSH keys, wildcard subdomains

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35591,12 +35591,12 @@ const create = async (vultr, region, plan, domain, id, osId, tag, sshKeyIds) => 
         (0, core_1.setOutput)("default_password", instance.default_password);
         (0, core_1.setOutput)("instance", instance);
         // create DNS records
-        const [dnsRecordA, dnsRecordCname] = await Promise.all([
+        const [dnsRecordA, wildcardRecordA] = await Promise.all([
             (0, api_1.createDnsRecord)(vultr, domain, id, "A", instanceIp),
-            (0, api_1.createDnsRecord)(vultr, `*.${domain}`, id, "A", instanceIp),
+            (0, api_1.createDnsRecord)(vultr, `*.${id}.${domain}`, id, "A", instanceIp),
         ]);
         console.log(`🌐 A record created with ID: ${dnsRecordA.id}`);
-        console.log(`🌐 A record (wildcard) created with ID: ${dnsRecordCname.id}`);
+        console.log(`🌐 A record (wildcard) created with ID: ${wildcardRecordA.id}`);
         // wait for server to fully spin up
         await (0, api_1.confirmInstanceIsReady)(vultr, instanceId);
         // sometimes the server isn't immediately ready for an ssh session

--- a/dist/index.js
+++ b/dist/index.js
@@ -35336,14 +35336,12 @@ const getAllInstances = async (vultr, region) => {
     return allInstances;
 };
 exports.getAllInstances = getAllInstances;
-const createDnsRecord = async (vultr, domain, id, type, instanceIp) => {
-    const name = type == "A" ? id : `*.${id}`;
-    const data = type == "A" ? instanceIp : `${id}.${domain}`;
+const createDnsRecord = async (vultr, domain, name, type, data) => {
     const res = await vultr.dns.createRecord({
         "dns-domain": domain,
-        name: name,
-        type: type,
-        data: data,
+        name,
+        type,
+        data,
     });
     // vultr-node doesn't necessarily throw a proper error if record creation fails
     if (!res?.record)
@@ -35593,7 +35591,7 @@ const create = async (vultr, region, plan, domain, id, osId, tag, sshKeyIds) => 
         // create DNS records
         const [dnsRecordA, wildcardRecordA] = await Promise.all([
             (0, api_1.createDnsRecord)(vultr, domain, id, "A", instanceIp),
-            (0, api_1.createDnsRecord)(vultr, `*.${id}.${domain}`, id, "A", instanceIp),
+            (0, api_1.createDnsRecord)(vultr, domain, `*.${id}.${domain}`, "A", instanceIp),
         ]);
         console.log(`🌐 A record created with ID: ${dnsRecordA.id}`);
         console.log(`🌐 A record (wildcard) created with ID: ${wildcardRecordA.id}`);

--- a/src/@vultr/vultr-node.d.ts
+++ b/src/@vultr/vultr-node.d.ts
@@ -30,6 +30,7 @@ declare module "@vultr/vultr-node" {
         label: string;
         hostname: string;
         tags: string[];
+        sshkey_id?: string[];
       }) => Promise<InstanceWrapper>;
 
       listInstances: (parameters: {

--- a/src/api.ts
+++ b/src/api.ts
@@ -76,17 +76,15 @@ export const getAllInstances = async (
 export const createDnsRecord = async (
   vultr: Vultr,
   domain: string,
-  id: string,
+  name: string,
   type: "A" | "CNAME",
-  instanceIp: string,
+  data: string,
 ): Promise<Record> => {
-  const name = type == "A" ? id : `*.${id}`;
-  const data = type == "A" ? instanceIp : `${id}.${domain}`;
   const res = await vultr.dns.createRecord({
     "dns-domain": domain,
-    name: name,
-    type: type,
-    data: data,
+    name,
+    type,
+    data,
   });
   // vultr-node doesn't necessarily throw a proper error if record creation fails
   if (!res?.record)

--- a/src/api.ts
+++ b/src/api.ts
@@ -113,6 +113,7 @@ export const createInstance = async (
   id: string,
   osId: string,
   tag: string,
+  sshKeyIds?: string[],
 ): Promise<Instance> => {
   const host = `${id}.${domain}`;
   const res = await vultr.instances.createInstance({
@@ -122,6 +123,7 @@ export const createInstance = async (
     label: host,
     hostname: host,
     tags: [tag], // 'tag' is deprecated
+    sshkey_id: sshKeyIds,
   });
   // vultr-node doesn't necessarily throw a proper error if instance creation fails
   if (!res?.instance)

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ const create = async (
     // create DNS records
     const [dnsRecordA, wildcardRecordA] = await Promise.all([
       createDnsRecord(vultr, domain, id, "A", instanceIp),
-      createDnsRecord(vultr, `*.${id}.${domain}`, id, "A", instanceIp),
+      createDnsRecord(vultr, domain, `*.${id}.${domain}`, "A", instanceIp),
     ]);
     console.log(`🌐 A record created with ID: ${dnsRecordA.id}`);
     console.log(

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,12 +189,14 @@ const create = async (
     setOutput("instance", instance);
 
     // create DNS records
-    const [dnsRecordA, dnsRecordCname] = await Promise.all([
+    const [dnsRecordA, wildcardRecordA] = await Promise.all([
       createDnsRecord(vultr, domain, id, "A", instanceIp),
-      createDnsRecord(vultr, `*.${domain}`, id, "A", instanceIp),
+      createDnsRecord(vultr, `*.${id}.${domain}`, id, "A", instanceIp),
     ]);
     console.log(`🌐 A record created with ID: ${dnsRecordA.id}`);
-    console.log(`🌐 A record (wildcard) created with ID: ${dnsRecordCname.id}`);
+    console.log(
+      `🌐 A record (wildcard) created with ID: ${wildcardRecordA.id}`
+    );
 
     // wait for server to fully spin up
     await confirmInstanceIsReady(vultr, instanceId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,8 @@ const main = async (): Promise<number> => {
   const domain = getVar("domain");
   const osType = getVar("os_type");
   const tag = getVar("tag");
+  // Accept comma separated list, ignoring spaces
+  const sshKeyIds = getVar("sshKeyIds").split(/\s*,\s*/);
 
   console.log(
     `🚀 running vultr script with following arguments:
@@ -45,7 +47,8 @@ const main = async (): Promise<number> => {
         domain=${domain}
         pullRequestId=${pullRequestId}
         osType=${osType}
-        tag=${tag}`,
+        tag=${tag}
+        sshKeyIds=${sshKeyIds}`
   );
 
   const osId = getOsId(osType);
@@ -79,6 +82,7 @@ const main = async (): Promise<number> => {
         pullRequestId,
         osId,
         tag,
+        sshKeyIds,
       );
     case "destroy":
       if (existingRecordIds.length == 0 || existingInstanceIds.length == 0) {
@@ -111,7 +115,10 @@ const checkIfDnsRecordsExist = async (
   const allRecords = await getAllRecords(vultr, domain);
   const existingRecords = allRecords.filter(
     ({ type, name }) =>
-      (type === "CNAME" && name === `*.${id}`) || (type === "A" && name === id),
+      (type === "A" && name === id) ||
+      (type === "A" && name === `*.${id}`) || 
+      (type === "TXT" && name === `_acme-challenge.${id}`),
+
   );
   // we don't handle any case where only 1 of 2 records has been created (this would require a manual fix)
   if (existingRecords.length > 0) {
@@ -153,6 +160,7 @@ const create = async (
   id: string,
   osId: string,
   tag: string,
+  sshKeyIds?: string[]
 ): Promise<number> => {
   // keep time for logging purposes
   const t0 = performance.now();
@@ -165,6 +173,7 @@ const create = async (
       id,
       osId,
       tag,
+      sshKeyIds,
     );
 
     const instanceId = instance.id;
@@ -182,10 +191,10 @@ const create = async (
     // create DNS records
     const [dnsRecordA, dnsRecordCname] = await Promise.all([
       createDnsRecord(vultr, domain, id, "A", instanceIp),
-      createDnsRecord(vultr, domain, id, "CNAME", instanceIp),
+      createDnsRecord(vultr, `*.${domain}`, id, "A", instanceIp),
     ]);
     console.log(`🌐 A record created with ID: ${dnsRecordA.id}`);
-    console.log(`🌐 CNAME record created with ID: ${dnsRecordCname.id}`);
+    console.log(`🌐 A record (wildcard) created with ID: ${dnsRecordCname.id}`);
 
     // wait for server to fully spin up
     await confirmInstanceIsReady(vultr, instanceId);


### PR DESCRIPTION
## What does this PR do?
- Optionally allows SSH keys to be installed on new Vultr instances
  - This will allow other CI actions to access instances via SSH keys, not password
  - This resolves an open issue on planx-new which is blocking CI
- Changes DNS record creation
  - From A record (`1234.planx.pizza` → IP) and CNAME record (`*.1234.planx.pizza` → `1234.planx.pizza`)
  - To A record (`1234.planx.pizza` → IP) and A record (`*.1234.planx.pizza` → IP)
  - This was intended to be required for wildcard certificates for Pizzas (not yet implemented) but has no real effect here

Implemented (pointing at [this pre-release](https://github.com/theopensystemslab/vultr-action/releases/tag/v2.2-beta-5), pointing at this branch) here - https://github.com/theopensystemslab/planx-new/pull/4751

Further context (OSL Slack) - https://opensystemslab.slack.com/archives/C01E3AC0C03/p1749028198799269

Once reviewed and merged, I'll create a release for v2.2 👍 