### PR TITLE
v2.3: add ssh_key_ids as required arg

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ inputs:
     required: true
   tag:
     required: true
+  ssh_key_ids:
+    required: true
 outputs:
   ip_address:
     description: "IP address"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vultr-action",
-  "version": "2.1",
+  "version": "2.3",
   "scripts": {
     "build": "ncc build src/index.ts -o dist --license licenses.txt"
   },
@@ -19,5 +19,5 @@
     "@actions/github": "^6.0.0",
     "@vultr/vultr-node": "^2.8.0"
   },
-  "packageManager": "pnpm@10.8.1+sha512.c50088ba998c67b8ca8c99df8a5e02fd2ae2e2b29aaf238feaa9e124248d3f48f9fb6db2424949ff901cffbb5e0f0cc1ad6aedb602cd29450751d11c35023677"
+  "packageManager": "pnpm@10.11.1"
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -111,7 +111,7 @@ export const createInstance = async (
   id: string,
   osId: string,
   tag: string,
-  sshKeyIds?: string[],
+  sshKeyIds: string[],
 ): Promise<Instance> => {
   const host = `${id}.${domain}`;
   const res = await vultr.instances.createInstance({

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ const main = async (): Promise<number> => {
   const osType = getVar("os_type");
   const tag = getVar("tag");
   // Accept comma separated list, ignoring spaces
-  const sshKeyIds = getVar("sshKeyIds").split(/\s*,\s*/);
+  const sshKeyIds = getVar("ssh_keys_ids").split(/\s*,\s*/);
 
   console.log(
     `🚀 running vultr script with following arguments:

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,7 +160,7 @@ const create = async (
   id: string,
   osId: string,
   tag: string,
-  sshKeyIds?: string[]
+  sshKeyIds: string[]
 ): Promise<number> => {
   // keep time for logging purposes
   const t0 = performance.now();


### PR DESCRIPTION
Minor follow up to #4, which just recognises `ssh_key_ids` as a required arg (and names it in the same format as other args), bumps pnpm for good measure, and tags as `2.3`.

Related PR in `planx-new`: https://github.com/theopensystemslab/planx-new/pull/4766

Noticed this needed implementing when I saw this warning in the CI flow:

![image](https://github.com/user-attachments/assets/b837721f-7fe5-49a1-9031-cf46e0015618)
