### PR TITLE
fix: ignore TXT DNS records when checking if resources already exist

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,12 +113,11 @@ const checkIfDnsRecordsExist = async (
     `🔍 checking for existing DNS records for pull request ${id} on domain ${domain}`,
   );
   const allRecords = await getAllRecords(vultr, domain);
+  // ignore any TXT records from a DNS challenge that the Caddy Vultr module failed to clean up
   const existingRecords = allRecords.filter(
     ({ type, name }) =>
       (type === "A" && name === id) ||
-      (type === "A" && name === `*.${id}`) || 
-      (type === "TXT" && name === `_acme-challenge.${id}`),
-
+      (type === "A" && name === `*.${id}`)
   );
   // we don't handle any case where only 1 of 2 records has been created (this would require a manual fix)
   if (existingRecords.length > 0) {


### PR DESCRIPTION
As per title - solves an issue where the action doesn't spin up a new instance or create `A` records when there are existing `TXT` acme challenge records. At least while we're debugging the wilcard cert problem, this is not desirable behaviour. See #[4757](https://github.com/theopensystemslab/planx-new/pull/4757) for more on this.

![image](https://github.com/user-attachments/assets/43c2ca0a-b0b1-42aa-aecd-a287b9dc3152)

extremely minor change so will merge w/o review to enable iteration on `planx-new` ✅ 